### PR TITLE
upgrade Pydantic version to fix TypeError crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ opencv_python_headless==4.7.0.68
 pandas==1.5.2
 Pillow==10.1.0
 prodigyopt==1.0
-pydantic==1.10.3
+pydantic>=1.10.4
 PyYAML==6.0.1
 Requests==2.31.0
 safetensors==0.3.1


### PR DESCRIPTION
With a fresh install on a fresh Ubuntu 22.04 vm, running the training script crashes with a TypeError:

```
Traceback (most recent call last):
  File "/home/user/sliders/trainscripts/textsliders/train_lora_xl.py", line 18, in <module>
    import prompt_util
  File "/home/user/sliders/trainscripts/textsliders/prompt_util.py", line 44, in <module>
    class PromptSettings(BaseModel):  # yaml のやつ
  File "pydantic/main.py", line 198, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 552, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 668, in pydantic.fields.ModelField._type_analysis
  File "/home/user/miniconda3/envs/sliders/lib/python3.9/typing.py", line 852, in __subclasscheck__
    return issubclass(cls, self.__origin__)
TypeError: issubclass() arg 1 must be a class
```

The cause is in requirements.txt: the pinned Pydantic version is a revoked release that had a bug. Using any newer Pydantic release fixes the crash.