### PR TITLE
Fix bugs for xformers disable and a BETTER way to fix "RuntimeError" for "lms" and "euler_a"

### DIFF
--- a/trainscripts/textsliders/train_lora.py
+++ b/trainscripts/textsliders/train_lora.py
@@ -65,7 +65,8 @@ def train(
     text_encoder.eval()
 
     unet.to(device, dtype=weight_dtype)
-    unet.enable_xformers_memory_efficient_attention()
+    if config.other.use_xformers:
+        unet.enable_xformers_memory_efficient_attention()
     unet.requires_grad_(False)
     unet.eval()
 
@@ -187,7 +188,7 @@ def train(
                 print("batch_size:", prompt_pair.batch_size)
 
             latents = train_util.get_initial_latents(
-                noise_scheduler, prompt_pair.batch_size, height, width, 1
+                noise_scheduler, prompt_pair.batch_size, height, width, 1, device
             ).to(device, dtype=weight_dtype)
 
             with network:

--- a/trainscripts/textsliders/train_lora_xl.py
+++ b/trainscripts/textsliders/train_lora_xl.py
@@ -192,7 +192,7 @@ def train(
                 print("dynamic_crops:", prompt_pair.dynamic_crops)
 
             latents = train_util.get_initial_latents(
-                noise_scheduler, prompt_pair.batch_size, height, width, 1
+                noise_scheduler, prompt_pair.batch_size, height, width, 1, device
             ).to(device, dtype=weight_dtype)
 
             add_time_ids = train_util.get_add_time_ids(

--- a/trainscripts/textsliders/train_util.py
+++ b/trainscripts/textsliders/train_util.py
@@ -18,7 +18,7 @@ UNET_PROJECTION_CLASS_EMBEDDING_INPUT_DIM = 2816
 
 
 def get_random_noise(
-    batch_size: int, height: int, width: int, generator: torch.Generator = None
+    batch_size: int, height: int, width: int, device: torch.device, generator: torch.Generator = None
 ) -> torch.Tensor:
     return torch.randn(
         (
@@ -27,8 +27,8 @@ def get_random_noise(
             height // VAE_SCALE_FACTOR,  # 縦と横これであってるのかわからないけど、どっちにしろ大きな問題は発生しないのでこれでいいや
             width // VAE_SCALE_FACTOR,
         ),
-        generator=generator,
-        device="cpu",
+        device=device,
+        generator=generator
     )
 
 
@@ -46,13 +46,14 @@ def get_initial_latents(
     height: int,
     width: int,
     n_prompts: int,
-    generator=None,
+    device: torch.device,
+    generator=None
 ) -> torch.Tensor:
-    noise = get_random_noise(n_imgs, height, width, generator=generator).repeat(
+    noise = get_random_noise(n_imgs, height, width, device, generator=generator).repeat(
         n_prompts, 1, 1, 1
     )
 
-    latents = noise * scheduler.init_noise_sigma
+    latents = noise * torch.tensor(scheduler.init_noise_sigma).to(device)
 
     return latents
 


### PR DESCRIPTION
Fix bugs for xformers disable and a BETTER way to fix "RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! for train.noise_scheduler: "lms", "euler_a""

Fix this #20 
And a better way than this #58 
